### PR TITLE
Deleting duplicated PATH option which makes trouble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,7 @@ RUN echo "export JAVA_HOME=$JAVA_HOME" >> $HADOOP_HOME/etc/hadoop/hadoop-env.sh 
     echo "export HDFS_NAMENODE_USER=root" >> $HADOOP_HOME/etc/hadoop/hadoop-env.sh && \
     echo "export HDFS_SECONDARYNAMENODE_USER=root" >> $HADOOP_HOME/etc/hadoop/hadoop-env.sh && \
     echo "export YARN_RESOURCEMANAGER_USER=root" >> $HADOOP_HOME/etc/hadoop/yarn-env.sh && \
-    echo "export YARN_NODEMANAGER_USER=root" >> $HADOOP_HOME/etc/hadoop/yarn-env.sh && \
-    echo "PATH=$PATH:$HADOOP_HOME/bin" >> ~/.bashrc
+    echo "export YARN_NODEMANAGER_USER=root" >> $HADOOP_HOME/etc/hadoop/yarn-env.sh
 
 
 RUN mkdir -pv $HADOOP_HOME/input


### PR DESCRIPTION
이미 위에 PATH 옵션으로 줬는데 bashrc 에 또 추가하는 것 때문에 문제가 발생합니다.

처음 알게 된 것인데

bashrc로 한번 세팅을 하면

다음에 PATH로 지정한 것들은 저장이 안되어서

ubuntu-hadoop을 base 이미지로 사용하는 경우

PATH 옵션이 먹통이 되어버림 (ubuntu-spark)


